### PR TITLE
Fixed versioning based on Git snapshot

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.68])
 AC_INIT([ibus-libthai],
-        m4_esyscmd([build-aux/git-version-gen]),
+        [m4_esyscmd([build-aux/git-version-gen])],
         [theppitak@gmail.com])
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
I find the current version of configure.ac causes aclocal to output
`error: AC_INIT should be called with package and version arguments`

Also, the tarball version file, as described in build-aux/git-version-gen, seems to be missing from the release tarball.